### PR TITLE
Update reading pymoca cache files

### DIFF
--- a/src/rtctools/optimization/modelica_mixin.py
+++ b/src/rtctools/optimization/modelica_mixin.py
@@ -48,9 +48,21 @@ class ModelicaMixin(OptimizationProblem):
             else:
                 model_name = self.__class__.__name__
 
-        self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
-            kwargs["model_folder"], model_name, self.compiler_options()
-        )
+        compiler_options = self.compiler_options()
+        logger.info(f"Loading/compiling model {model_name}.")
+        try:
+            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
+                kwargs["model_folder"], model_name, compiler_options
+            )
+        except RuntimeError as error:
+            if compiler_options.get("cache", False):
+                raise error
+            compiler_options["cache"] = False
+            logger.warning(f"Loading model {model_name} using a cache file failed: {error}.")
+            logger.info(f"Compiling model {model_name}.")
+            self.__pymoca_model = pymoca.backends.casadi.api.transfer_model(
+                kwargs["model_folder"], model_name, compiler_options
+            )
 
         # Extract the CasADi MX variables used in the model
         self.__mx = {}


### PR DESCRIPTION
In GitLab by @SGeeversAtVortech on Apr 2, 2024, 14:18

Try loading a model from a pymoca cache file when available,
but when this results in a runtime error,
compile the model instead.

Loading errors may occur when the pymoca cache file was generated
in a different environment.