### PR TITLE
Bspline1 include ipopt options argument

### DIFF
--- a/src/rtctools/data/interpolation/bspline1d.py
+++ b/src/rtctools/data/interpolation/bspline1d.py
@@ -55,6 +55,7 @@ class BSpline1D(BSpline):
         epsilon=1e-7,
         delta=1e-4,
         interior_pts=None,
+        ipopt_options=None,
     ):
         """
         fit() returns a tck tuple like scipy.interpolate.splrep, but adjusts
@@ -153,7 +154,10 @@ class BSpline1D(BSpline):
         nlp = {"x": c, "f": f, "g": g}
         my_solver = "ipopt"
         solver = nlpsol(
-            "solver", my_solver, nlp, {"print_time": 0, "expand": True, "ipopt": {"print_level": 0}}
+            "solver",
+            my_solver,
+            nlp,
+            {"print_time": 0, "expand": True, "ipopt": ipopt_options},
         )
         sol = solver(lbg=lbg, ubg=ubg)
         stats = solver.stats()

--- a/tests/data/test_interpolate.py
+++ b/tests/data/test_interpolate.py
@@ -43,6 +43,43 @@ class TestBSpline1DFit(TestCase):
         y_slope_list = y_list[1:] - y_list[:-1]
         self.assertTrue(np.all((y_slope_list[1:] - y_slope_list[:-1]) < 0))
 
+    def test_fit(self):
+        """
+        Regression test for BSpline1D.fit.
+
+        This checks that BSpline1D.fit succeeds for a particular case when using
+        the nlp option nlp_scaling_method=none.
+        """
+        x = [4.91, 5.92, 10.83, 11.16, 11.51]
+        y = [1.124038e08, 1.354540e08, 2.475718e08, 2.551113e08, 2.631086e08]
+        t, c, k = rtctools.data.interpolation.bspline1d.BSpline1D.fit(
+            x=x,
+            y=y,
+            k=3,
+            monotonicity=1,
+            curvature=0,
+            ipopt_options={"nlp_scaling_method": "none"},
+        )
+        t_ref = np.array(
+            [4.9099, 4.9099, 4.9099, 4.9099, 10.83, 11.5101, 11.5101, 11.5101, 11.5101]
+        )
+        c_ref = np.array(
+            [
+                1.12401518e08,
+                1.57433811e08,
+                2.07664058e08,
+                2.57930573e08,
+                2.63110885e08,
+                2.63210885e08,
+                2.63310885e08,
+                2.63410885e08,
+                2.63510885e08,
+            ]
+        )
+        np.testing.assert_almost_equal(t, t_ref)
+        np.testing.assert_almost_equal(c, c_ref, decimal=0)
+        self.assertEqual(k, 3)
+
 
 # class TestBSpline2D(TestCase):
 #     def setUp(self):


### PR DESCRIPTION
In GitLab by @jarsarasty on Jul 10, 2024, 09:47

In the Casadi 3.6.\*, the `nlp_scaling_method` option of ipopt caused infeasibilities in some models using the `BSpline1D` class. 

This pull request includes `ipopt_options` as an argument in the `fit` class method of `BSpline1D`. Using `ipopt_options`, the `nlp_scaling_method` option can be set to "`none`" by the user to avoid autoscaling issues in ipopt.

This pull request is linked to [this issue](https://gitlab.com/deltares/rtc-tools/-/issues/1142 "BSpline1D interpolation fails").

After this merge request, the corresponding models can be adjustes in the test bench. See [here](https://issuetracker.deltares.nl/browse/RTCTOOLS-1137).