### PR TITLE
WIP: Merge goal programming mixin

### DIFF
--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -452,9 +452,12 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
                     expr += ca.sum1(self.map_path_expression(self.__path_objective(old_path_objs, ensemble_member),
                                                              ensemble_member))
                     tot_expr += self.ensemble_member_probability(ensemble_member) * expr
-                # Add a relaxation to the value
-                val += self.goal_programming_options()['constraint_relaxation']
-                constraints.append((tot_expr, -np.inf, val))
+                if self.goal_programming_options()['fix_minimized_values']:
+                    constraints.append((tot_expr, val, val))
+                else:
+                    # Add a relaxation to the value
+                    val += self.goal_programming_options()['constraint_relaxation']
+                    constraints.append((tot_expr, -np.inf, val))
             if self.goal_programming_options()['linear_obj_eps']:
                 # Epsilon alias constraints
                 for constraint_eps in self.__problem_constraint_epsilons_alias[ensemble_member]:


### PR DESCRIPTION
In GitLab by @TPiovesan on Aug 30, 2018, 17:14

There are two possible ways to do goal programming:
*  current way: the evaluation of the epsilon variables is used to create hard constraints;
*  new way: the epsilon are kept as variables throughout the goal programming.
The switching between the two possibilities can be done via the options 'keep_eps_variable'. The default is set to False, which implies that the current goal programming option is chosen.

If 'keep_eps_variable' is set to True, one can use the further option 'linear_obj_eps'. This ensures that any objective function throughout the optimization problem is linear. This option is useful, e.g., to use solvers that can handle linear objective and quadratic constrained programming, but not quadratic objective and quadratic constrained programming.