### PR TITLE
WIP: Simulation PIMixin: get canonical name before saving data to the output object

### DIFF
--- a/src/rtctools/simulation/pi_mixin.py
+++ b/src/rtctools/simulation/pi_mixin.py
@@ -170,7 +170,8 @@ class PIMixin(SimulationProblem):
 
         # Extract consistent t0 values
         for variable in self.__output_variables:
-            self.__output[variable][self.__timeseries_import.forecast_index] = self.get_var(variable)
+            name, sign = self.alias_relation.canonical_signed(variable)
+            self.__output[name][self.__timeseries_import.forecast_index] = self.get_var(name)
 
     def update(self, dt):
         # Time step
@@ -197,7 +198,8 @@ class PIMixin(SimulationProblem):
 
         # Extract results
         for variable in self.__output_variables:
-            self.__output[variable][t_idx] = self.get_var(variable)
+            name, sign = self.alias_relation.canonical_signed(variable)
+            self.__output[name][t_idx] = self.get_var(name)
 
     def post(self):
         # Call parent class first for default behaviour.


### PR DESCRIPTION
In GitLab by @OJMvD on Oct 23, 2018, 14:20

Previously, the simulation PIMixin tried to save simulation results using the timeseries id as defined in rtcDataConfig.xml. For the variables for which the timeseries id did not match the canonical name resulting from the alias relation, this would lead to empty series in the timeseries_export.xml. This is solved by saving (and acquiring) model results using the canonical name.