### PR TITLE
WIP: Support absolute goal order for minimization goals

### DIFF
--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -427,6 +427,8 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
         self.__problem_abs_vars = []
         self.__problem_path_abs_constraints = _EmptyEnsembleList()
         self.__problem_path_abs_vars = []
+        self.__abs_seeds = _EmptyEnsembleOrderedDict()
+        self.__abs_path_seeds = _EmptyEnsembleOrderedDict()
 
     @property
     def extra_variables(self):

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -848,9 +848,9 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
 
             if goal.minimize_absolute_value:
                 if goal.function_range != (np.nan, np.nan):
-                    raise Exception("Absolute goal function is only allowed for minimization for goal {}".format(goals))
+                    raise Exception("Absolute goal function is only allowed for minimization for goal {}".format(goal))
                 if goal.order != 1:
-                    raise Exception("Absolute goal function is only allowed for order 1 for goal {}".format(goals))
+                    raise Exception("Absolute goal function is only allowed for order 1 for goal {}".format(goal))
 
         if is_path_goal:
             target_shape = len(self.times())

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -1328,6 +1328,7 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
                 # Copy relevant properties
                 self.size = orig_goal.size
                 self.weight = orig_goal.weight
+                self.priority = orig_goal.priority
                 self.relaxation = orig_goal.relaxation / orig_goal.function_nominal
 
             def function(self, optimization_problem, ensemble_member):

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -440,7 +440,7 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
             bounds[epsilon.name()] = (0.0, 1.0)
 
         for abs_var in (self.__problem_abs_vars + self.__problem_path_abs_vars):
-            bounds[abs_var.name()] = (-np.inf, np.inf)
+            bounds[abs_var.name()] = (0.0, np.inf)
 
         return bounds
 
@@ -1307,6 +1307,9 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
         # TODO: Can we figure out good bounds? What about a good initial seed value?
 
         class _AbsoluteMinimizationGoal(Goal):
+
+            order = 1
+
             def __init__(self, abs_variable, is_path_goal, orig_goal):
                 self.abs_variable = abs_variable
                 self.is_path_goal = is_path_goal
@@ -1328,14 +1331,16 @@ class GoalProgrammingMixin(OptimizationProblem, metaclass=ABCMeta):
         constraints = [[] for ensemble_member in range(ensemble_size)]
         variables = []
 
-        # Make a copy, because we will be modifying an absolute goal in place
+        # It is easier to modify goals in place, but we do not want to modify
+        # the original input list of goals. Make a copy to work with and
+        # return when we are done.
         goals = goals.copy()
 
         for j, goal in enumerate(goals):
             if not isinstance(goal.order, str):
                 continue
 
-            abs_variable_name = "_abs_{}_{}".format(sym_index, j)
+            abs_variable_name = "abs_{}_{}".format(sym_index, j)
             if is_path_goal:
                 abs_variable_name = "path_" + abs_variable_name
 

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -170,7 +170,8 @@ class Goal(metaclass=ABCMeta):
 
     #: The goal violation value is taken to the order'th power in the objective
     #: function. Minimization of the absolute function value is allowed by
-    #: specifying "abs" for the order.
+    #: specifying "abs" for the order. Note that this will only be convex if
+    #: the goal function is linear.
     order = 2
 
     #: The size of the goal if it's a vector goal.

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -904,7 +904,8 @@ class TestGoalMinimizeSqU(TestGoalPrio2MinimizeU):
 
 
 class TestGoalMinimizeAbsU(TestGoalPrio2MinimizeU):
-    order = "abs"
+    order = 1
+    minimize_absolute_value = True
 
 
 class TestInvalidGoalTargetAbsU(TestGoalMinimizeAbsU):


### PR DESCRIPTION
In GitLab by @vreeken on Dec 30, 2018, 22:19

One would typically use order=2 to minimize the absolute value of the goal
function, but that makes nominals a bit harder and easily leads to scaling
issues. A more involved option that was used is to introduce an auxiliary
variable and additional constraints to minimize the absolute value of the
goal function.

It is the latter logic that this commit adds to GoalProgrammingMixin, such
that the user now only has to set order="abs" on a Goal instance. The
auxiliary variable and accompanying constraints are automatically added
behind the scenes.

Closes #1060

TODO:
* [ ]  Do not abuse goal order for this, but introduce a new flag.