### PR TITLE
WIP: Fix initial_state() and history()

### DIFF
--- a/src/rtctools/optimization/io_mixin.py
+++ b/src/rtctools/optimization/io_mixin.py
@@ -7,7 +7,6 @@ import casadi as ca
 
 import numpy as np
 
-from rtctools._internal.alias_tools import AliasDict
 from rtctools._internal.caching import cached
 from rtctools.optimization.optimization_problem import OptimizationProblem
 from rtctools.optimization.timeseries import Timeseries
@@ -219,7 +218,7 @@ class IOMixin(OptimizationProblem, metaclass=ABCMeta):
     @cached
     def history(self, ensemble_member):
         # Load history
-        history = AliasDict(self.alias_relation)
+        history = super().history(ensemble_member)
 
         end_index = bisect.bisect_left(self.io.times_sec, self.initial_time) + 1
 

--- a/src/rtctools/optimization/modelica_mixin.py
+++ b/src/rtctools/optimization/modelica_mixin.py
@@ -207,7 +207,7 @@ class ModelicaMixin(OptimizationProblem):
 
     @cached
     def initial_state(self, ensemble_member):
-        initial_state = AliasDict(self.alias_relation)
+        initial_state = super().initial_state(ensemble_member)
 
         # Parameter values
         parameters = self.parameters(ensemble_member)

--- a/src/rtctools/optimization/optimization_problem.py
+++ b/src/rtctools/optimization/optimization_problem.py
@@ -399,7 +399,7 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
 
     def history(self, ensemble_member: int) -> AliasDict[str, Timeseries]:
         """
-        Returns the state history.  Uses the initial_state() method by default.
+        Returns the state history. Calls :py:meth:`initial_state` by default for values at t0.
 
         :param ensemble_member: The ensemble member index.
 
@@ -443,18 +443,15 @@ class OptimizationProblem(DataStoreAccessor, metaclass=ABCMeta):
         """
         The initial state.
 
-        The default implementation uses t0 data returned by the ``history`` method.
+        The default implementation returns an empty :py:class:`.AliasDict`.
+        Note that is a convencience method called by :py:meth:`history` for
+        additional values at t0.
 
         :param ensemble_member: The ensemble member index.
 
         :returns: A dictionary of variable names and initial state (t0) values.
         """
-        t0 = self.initial_time
-        history = self.history(ensemble_member)
-        return AliasDict(
-            self.alias_relation,
-            {variable: self.interpolate(t0, timeseries.times, timeseries.values)
-             for variable, timeseries in history.items()})
+        return AliasDict(self.alias_relation, {})
 
     @property
     def initial_residual(self) -> ca.MX:

--- a/src/rtctools/optimization/pi_mixin.py
+++ b/src/rtctools/optimization/pi_mixin.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 import rtctools.data.pi as pi
 import rtctools.data.rtc as rtc
-from rtctools._internal.caching import cached
 from rtctools.optimization.io_mixin import IOMixin
 
 logger = logging.getLogger("rtctools")
@@ -142,18 +141,6 @@ class PIMixin(IOMixin):
 
         # Done
         return options
-
-    @cached
-    def initial_state(self, ensemble_member):
-        # Call parent class first for default values.
-        initial_state = super().initial_state(ensemble_member)
-
-        history = self.history(ensemble_member)
-
-        for variable, timeseries in history.items():
-            initial_state[variable] = timeseries.values[-1]
-
-        return initial_state
 
     def write(self):
         # Call parent class first for default behaviour.

--- a/tests/optimization/test_pi_mixin.py
+++ b/tests/optimization/test_pi_mixin.py
@@ -62,10 +62,10 @@ class TestPIMixin(TestCase):
         self.assertEqual(params["SV_H_y"], 22.02)
         self.assertEqual(params["SV_H_y"], params["SV_V_y"])
 
-    def test_initial_state(self):
-        initial_state = self.problem.initial_state(0)
-        self.assertAlmostEqual(initial_state["x"], 1.02, self.tolerance)
-        self.assertAlmostEqual(initial_state["v_initial"], 2.1, self.tolerance)
+    def test_history(self):
+        history = self.problem.history(0)
+        self.assertAlmostEqual(history["x"].values[-1], 1.02, self.tolerance)
+        self.assertAlmostEqual(history["v_initial"].values[-1], 2.1, self.tolerance)
 
     def test_seed(self):
         seed = self.problem.seed(0)


### PR DESCRIPTION
In GitLab by @vreeken on Sep 17, 2019, 22:35

* [x]  On top of !323 


* [ ]  After some more discussion, it actually seems better to just remove initial_state. There are so many things that can be very confusing when keeping both around.

Before we had the supposed default implementation in OptimizationProblem
that history() also returned values in initial_state(), and vice versa.
This would never actually work properly, as one would end up in an
endless loop.

The reason this bug was not encountered until this point, is that
ModelicaMixin did _not_ call super() for initial_state(). Furthermore,
PIMixin/IOMixin did _not_ call super() either. So in practice we never
got the behavior that history() referred to values in intial_state() and
vice versa.

The "mother" method of the two is history(), as this is the only method
actually called in CollocatedIntegratedOptimizationProblem. This means
that when a user uses any IOMixin class, but implements their own
initial_state() method, this method would never actually be called.

To fix this bug, we remove the supposed referral of initial_state() to
history() (which was not there in practice), but we keep the call to
initial_state() in OptimizationProblem's implementation of history(). We
also make sure that all classes properly call their respective super()
methods.

Closes #1123