### PR TITLE
WIP: adds option to use weights as timeseries in goal_programming_mixin_base

### DIFF
--- a/src/rtctools/optimization/goal_programming_mixin_base.py
+++ b/src/rtctools/optimization/goal_programming_mixin_base.py
@@ -551,6 +551,9 @@ class _GoalProgrammingMixinBase(OptimizationProblem, metaclass=ABCMeta):
                     raise Exception("Invalid function range for goal {}".format(goal))
 
                 if isinstance(goal.weight, Timeseries):
+                    if len(goal.weight.times) > 1 and not is_path_goal:
+                        raise Exception("Non path goals require a scalar weight.")
+
                     if (len(goal.weight.times) != len(self.times())) or \
                        (len(goal.weight.values) != len(self.times())):
                         raise Exception("Goal weight timeseries of goal {} should be of equal \

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -1165,8 +1165,8 @@ class TestGoalProgrammingVariousGoalWeigths(TestCase):
     def test_weights_as_series(self):
         vars = list(self.problem1.extract_results().keys())
         for var in vars:
-            self.assertAlmostEqual(self.problem1.extract_results()[var],
-                                   self.problem2.extract_results()[var], 1e-3)
+            self.assertEqual(self.problem1.extract_results()[var],
+                             self.problem2.extract_results()[var])
             self.assertFalse(
-                self.assertAlmostEqual(self.problem1.extract_results()[var],
-                                       self.problem3.extract_results()[var], 1e-3))
+                self.assertEqual(self.problem1.extract_results()[var],
+                                 self.problem3.extract_results()[var]))

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -921,6 +921,15 @@ class InvalidGoal(Goal):
         return optimization_problem.state_at("x", 0.5, ensemble_member=ensemble_member)
 
 
+# class InvalidPathGoal(Goal):
+#
+#     def __init__(self, **kwargs):
+#         self.__dict__.update(kwargs)
+#
+#     def function(self, optimization_problem, ensemble_member):
+#         return optimization_problem.state_at("x", 0.5, ensemble_member=ensemble_member)
+
+
 class TestGoalProgrammingInvalidGoals(TestCase):
 
     def setUp(self):
@@ -1023,6 +1032,10 @@ class TestGoalProgrammingInvalidGoals(TestCase):
         with self.assertRaisesRegex(Exception, "Goal weight timeseries of goal .* should be of equal \
 length as the number of colocation points in time"):
             self.problem.optimize()
+
+    def test_nonscalar_weigth_with_nonpathgoal(self):
+        invalid_weight = Timeseries(self.problem.times(), np.linspace(1.0, 0.0, 10))
+        self.problem._goals = [InvalidGoal(function_range=(-2.0, 2.0), target_max=1.0, weight=invalid_weight)]
 
 
 class ModelPathGoalsSeed(ModelPathGoals):

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -17,6 +17,7 @@ from test_case import TestCase
 
 from .data_path import data_path
 
+
 logger = logging.getLogger("rtctools")
 logger.setLevel(logging.WARNING)
 
@@ -1006,7 +1007,22 @@ class TestGoalProgrammingInvalidGoals(TestCase):
     def test_goal_weight_targets(self):
         self.problem._goals = [InvalidGoal(function_range=(-2.0, 2.0), target_max=1.0, weight=-1.0)]
 
-        with self.assertRaisesRegex(Exception, "Goal weight should be positive"):
+        with self.assertRaisesRegex(Exception, "Scalar goal weight should be positive"):
+            self.problem.optimize()
+
+    def test_weights_as_negative_timeseries(self):
+        invalid_weight = Timeseries(self.problem.times(), np.linspace(1.0, -1.0, 21))
+        self.problem._goals = [InvalidGoal(function_range=(-2.0, 2.0), target_max=1.0, weight=invalid_weight)]
+
+        with self.assertRaisesRegex(Exception, "Goal weight timeseries of goal .* should be non-negative."):
+            self.problem.optimize()
+
+    def test_weights_as_too_short_timeseries(self):
+        invalid_weight = Timeseries(self.problem.times(), np.linspace(1.0, 0.0, 10))
+        self.problem._goals = [InvalidGoal(function_range=(-2.0, 2.0), target_max=1.0, weight=invalid_weight)]
+
+        with self.assertRaisesRegex(Exception, "Goal weight timeseries of goal .* should be of equal \
+length as the number of colocation points in time"):
             self.problem.optimize()
 
 

--- a/tests/optimization/test_goal_programming.py
+++ b/tests/optimization/test_goal_programming.py
@@ -17,7 +17,6 @@ from test_case import TestCase
 
 from .data_path import data_path
 
-
 logger = logging.getLogger("rtctools")
 logger.setLevel(logging.WARNING)
 


### PR DESCRIPTION
In GitLab by @RSinnige on Jan 27, 2020, 16:09

Adds option to use weights as timeseries in goal_programming_mixin_base next to the use of scalar goal weights.
Scalar goal weights should be positive, while timeseries-values should be nonnegative.

TODO:
* write function to make the correct constraints.

resolves #1038