### PR TITLE
WIP: Output units for pi and net cdf

### DIFF
--- a/src/rtctools/data/pi.py
+++ b/src/rtctools/data/pi.py
@@ -979,6 +979,9 @@ class Timeseries:
         :param unit:            Unit.
         :param ensemble_member: Ensemble member index.
         """
+        if ensemble_member >= len(self.__units):
+            self.__units.append({})
+
         self.__units[ensemble_member][variable] = unit
 
     def resize(self, start_datetime, end_datetime):

--- a/src/rtctools/optimization/netcdf_mixin.py
+++ b/src/rtctools/optimization/netcdf_mixin.py
@@ -36,6 +36,8 @@ class NetCDFMixin(IOMixin):
 
     #: Check consistency of timeseries.
     netcdf_validate_timeseries = True
+    #: Placeholder for dictionary of units to be set as attribute of variables in output
+    netcdf_output_units = OrderedDict()
 
     def netcdf_id_to_variable(self, station_id: str, parameter: str) -> str:
         """
@@ -109,6 +111,11 @@ class NetCDFMixin(IOMixin):
 
         logger.debug("NetCDFMixin: Read timeseries")
 
+        # TODO: unit test
+        self.__input_attributes = OrderedDict()
+        for var in timeseries_var_keys:
+            self.__input_attributes[var] = dataset.read_variable_attributes(var)
+
     def write(self):
         # Call parent class first for default behaviour
         super().write()
@@ -132,6 +139,7 @@ class NetCDFMixin(IOMixin):
         dataset.write_ensemble_data(self.ensemble_size)
 
         dataset.create_variables(unique_parameter_ids, self.ensemble_size)
+        dataset.write_output_units(unique_parameter_ids, self.netcdf_output_units)
 
         for ensemble_member in range(self.ensemble_size):
             results = self.extract_results(ensemble_member)

--- a/src/rtctools/optimization/pi_mixin.py
+++ b/src/rtctools/optimization/pi_mixin.py
@@ -210,7 +210,7 @@ class PIMixin(IOMixin):
                 # we might be outputting more ensembles than we read in.
                 self.__timeseries_export.set(
                     variable, values,
-                    unit=self.__timeseries_import.get_unit(variable, ensemble_member=0),
+                    unit=self.__timeseries_export.get_unit(variable, ensemble_member=0),
                     ensemble_member=ensemble_member)
 
         # Write output file to disk


### PR DESCRIPTION
In GitLab by @RSinnige on Jan 30, 2020, 17:38

adds the units from the import timeseries to the output timeseries and tries to infer the unit from the output variable name otherwise.

TODO:

* Currently individual pytests succeed but `test_netcdf_mixin` fails in the pipeline. Likely a cleanup in one of the previously run tests needs to be added.

* write unit tests for:
  +  `read_variable_attributes` in `netcdf`
  +  `_add_output_units` in `io_mixin` 
  +  `write_output_units` in `netcdf`

resolves: #1129 and #1112