### PR TITLE
draft: update writing variables to xml file

### DIFF
--- a/src/rtctools/simulation/pi_mixin.py
+++ b/src/rtctools/simulation/pi_mixin.py
@@ -143,7 +143,11 @@ class PIMixin(IOMixin):
         # For all variables that are output variables the values are
         # extracted from the results.
         for variable in self._io_output_variables:
-            for alias in self.alias_relation.aliases(variable):
+            aliases = self.alias_relation.aliases(variable).copy()
+            # Ensure that variable is the first in the list of aliases
+            aliases.remove(variable)
+            aliases = [variable, *aliases]
+            for alias in aliases:
                 values = np.array(self._io_output[alias])
                 # Check if ID mapping is present
                 try:


### PR DESCRIPTION
In GitLab by @SGeeversAtVortech on May 9, 2023, 15:32

When writing a variable to an xml file,
it will loop over all aliases of this variable.
The first alias that is in the rtcDataConfig file will be written
to the xml file.
The order of the aliases is random and therefore the actual
variable that will be written is random.
By ensuring that the original variable appears first in the list
of aliases the behaviour is a bit less random and unexpected,
especially when the variable itself is in the variable file.