### PR TITLE
Draft: read in changes to parameters in set_parameter

### DIFF
--- a/src/rtctools/data/storage.py
+++ b/src/rtctools/data/storage.py
@@ -273,7 +273,7 @@ class DataStore:
         Returns an AliasDict of parameters to its values for the specified ensemble member.
         """
         if ensemble_member >= self.__ensemble_size:
-            raise KeyError("ensemble_member {} does not exist".format(ensemble_member))
+            self.__update_ensemble_size(ensemble_member + 1)
         return self.__parameters[ensemble_member]
 
     @staticmethod

--- a/src/rtctools/optimization/goal_programming_mixin.py
+++ b/src/rtctools/optimization/goal_programming_mixin.py
@@ -93,6 +93,8 @@ class GoalProgrammingMixin(_GoalProgrammingMixinBase):
 
     def parameters(self, ensemble_member):
         parameters = super().parameters(ensemble_member)
+        for parameter, value in self.io.parameters(ensemble_member).items():
+            parameters[parameter] = value
 
         if ensemble_member not in self.__original_parameter_keys:
             self.__original_parameter_keys[ensemble_member] = set(parameters.keys())


### PR DESCRIPTION
In GitLab by @Ailbhemit on Aug 4, 2023, 10:40

The parameters definition is cached and thus edits to parameters made
by set_parameter function were not picked up. These lines check with
the stored parameter values and update these of needed.