### PR TITLE
Revert "simulation: change time-step solver to fast_newton"

### DIFF
--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -708,8 +708,13 @@ class SimulationProblem(DataStoreAccessor):
                 pass
 
         # Use rootfinder() to make a function that takes a step forward in time by trying to zero
-        # res_vals().
-        self.__do_step = ca.rootfinder("next_state", "fast_newton", self.__res_vals)
+        # res_vals()
+        options = {
+            "nlpsol": "ipopt",
+            "nlpsol_options": self.solver_options(),
+            "error_on_fail": False,
+        }
+        self.__do_step = ca.rootfinder("next_state", "nlpsol", self.__res_vals, options)
 
     def pre(self):
         """


### PR DESCRIPTION
In GitLab by @SGeeversAtVortech on Dec 19, 2023, 16:31

This reverts commit d2c97f4789ced0f1f492d957ade94e6da0032ff4.

The fast_newton solver failed to find a solution for certain models.
To prevent current use casse from suddenly breaking,
the idea is to return to the previous solver.
In the future, an option will be added to SimulationProblem
with which the user can select his/her own solver for the implicit
time step updates.