### PR TITLE
workflows: add work flow based on the gitlab ci workflow

### DIFF
--- a/.github/workflows/rtc-tools.yml
+++ b/.github/workflows/rtc-tools.yml
@@ -1,0 +1,106 @@
+name: deltares/rtc-tools
+
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+# env:
+#   PYPI_USER: "${{ secrets.PYPI_USER }}"
+#   PYPI_PASSWORD: "${{ secrets.PYPI_PASSWORD }}"
+#   CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN}}"
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install pre-commit
+    - run: pre-commit run --all-files --show-diff-on-failure
+
+  build:
+    needs: style
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.9
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - run: python setup.py sdist bdist_wheel
+    - uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        retention-days: 7
+        path: dist/
+
+  test-linux:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.version }}
+    timeout-minutes: 30
+    env:
+      TOXENV: py
+    strategy:
+      matrix:
+        version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install tox
+    - run: tox -vv
+
+  coverage:
+    needs: test-linux
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.9
+    timeout-minutes: 30
+    env:
+      TOXENV: coverage
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - run: pip install tox
+    - run: tox -vv
+  #   - run: pip install codecov
+  #   - run: codecov --token=$CODECOV_TOKEN
+
+  examples-linux:
+    needs: coverage
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.version }}
+    if: startsWith(github.ref, 'refs/tags')
+    timeout-minutes: 30
+    env:
+      TOXENV: examples
+    strategy:
+      matrix:
+        version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - run: pip install tox
+    - run: tox -vv
+
+  # deploy:
+  #   needs: examples-linux
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: python:3.9
+  #   if: (github.ref == 'refs/tags//^2\..*$/') && !(startsWith(github.ref, 'refs/heads'))
+  #   timeout-minutes: 30
+  #   steps:
+  #   - uses: actions/checkout@v4.1.0
+  #   - uses: actions/download-artifact@v4.1.0
+  #     with:
+  #       name: "${{ github.job }}"
+  #   - run: pip install twine
+  #   - run: twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*


### PR DESCRIPTION
Add a github workflow based on the gitlab CI workflow.

Private tokens to access codecov and pypi are still missing.

Tests are no longer executed with python 3.8,
since this version is almost end-of-life
and seems to sometimes result in a mysterious crash during package installation, resulting in a message "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE" for an "unknown package".