### PR TITLE
Remove dependency on pkg resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ RTC-Tools uses [CasADi](https://web.casadi.org/) as a symbolic framework for alg
 pip install rtc-tools
 ```
 
-When using Python 3.12 or higher, you might first need to install setuptools
-
-```bash
-pip install setuptools
-```
-
 ## Documentation
 
 Documentation and examples can be found on [readthedocs](https://rtc-tools.readthedocs.io).

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -21,10 +21,6 @@ RTC-Tools, including its dependencies, can be installed using the `pip <https://
     # Install RTC-Tools using pip package manager
     pip install rtc-tools
 
-When using Python 3.12 or higher, you might first need to install setuptools::
-
-    pip install setuptools
-
 From Source
 -----------
 
@@ -40,10 +36,6 @@ Then you can install this latest version as follows::
 Or if you would like to have an editable installation (e.g. as developer)::
 
     pip install -e ./rtc-tools
-
-When using Python 3.12 or higher, you might first need to install setuptools::
-
-    pip install setuptools
 
 Note that rtc-tools-channel-flow is a dependency of rtc-tools which is included in the above installations. 
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
         "pymoca >= 0.9.1, == 0.9.*",
         "rtc-tools-channel-flow >= 1.2.0",
         "defusedxml >= 0.7.0",
+        # Python 3.9's importlib.metadata does not support the "group" parameter
+        # to entry_points yet.
+        "importlib_metadata >= 5.0.0; python_version < '3.10'",
     ],
     tests_require=["pytest", "pytest-runner", "netCDF4"],
     extras_require={

--- a/src/rtctools/optimization/modelica_mixin.py
+++ b/src/rtctools/optimization/modelica_mixin.py
@@ -1,10 +1,18 @@
+import importlib.resources
 import itertools
 import logging
+import sys
 from typing import Dict, Union
+
+# Python 3.9's importlib.metadata does not support the "group" parameter to
+# entry_points yet.
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
 
 import casadi as ca
 import numpy as np
-import pkg_resources
 import pymoca
 import pymoca.backends.casadi.api
 
@@ -174,9 +182,9 @@ class ModelicaMixin(OptimizationProblem):
         # Where imported model libraries are located.
         library_folders = self.modelica_library_folders.copy()
 
-        for ep in pkg_resources.iter_entry_points(group="rtctools.libraries.modelica"):
+        for ep in importlib_metadata.entry_points(group="rtctools.libraries.modelica"):
             if ep.name == "library_folder":
-                library_folders.append(pkg_resources.resource_filename(ep.module_name, ep.attrs[0]))
+                library_folders.append(str(importlib.resources.files(ep.module).joinpath(ep.attr)))
 
         compiler_options["library_folders"] = library_folders
 

--- a/src/rtctools/simulation/simulation_problem.py
+++ b/src/rtctools/simulation/simulation_problem.py
@@ -1,13 +1,21 @@
 import copy
+import importlib.resources
 import itertools
 import logging
 import math
+import sys
 from collections import OrderedDict
 from typing import List, Union
 
+# Python 3.9's importlib.metadata does not support the "group" parameter to
+# entry_points yet.
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
+
 import casadi as ca
 import numpy as np
-import pkg_resources
 import pymoca
 import pymoca.backends.casadi.api
 
@@ -1244,9 +1252,9 @@ class SimulationProblem(DataStoreAccessor):
         # Where imported model libraries are located.
         library_folders = self.modelica_library_folders.copy()
 
-        for ep in pkg_resources.iter_entry_points(group="rtctools.libraries.modelica"):
+        for ep in importlib_metadata.entry_points(group="rtctools.libraries.modelica"):
             if ep.name == "library_folder":
-                library_folders.append(pkg_resources.resource_filename(ep.module_name, ep.attrs[0]))
+                library_folders.append(str(importlib.resources.files(ep.module).joinpath(ep.attr)))
 
         compiler_options["library_folders"] = library_folders
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
 [testenv]
 deps =
   pytest
-  setuptools  # Required for Python 3.12.
 extras = all
 install_command = pip install --only-binary=netcdf4 {opts} netcdf4 {packages}
 commands =
@@ -18,7 +17,6 @@ commands =
 deps =
   coverage
   pytest
-  setuptools  # Required for Python 3.12.
 commands =
   - coverage run --parallel-mode -m pytest --ignore=tests/examples {posargs} tests
   - coverage combine


### PR DESCRIPTION
The pkg_resources package has been removed from the Python standard
library in version 3.12, while still available when (manually)
installing setuptools. A more modern approach is the usage of
"importlib", available since Python 3.9. Note that we do require a
change to "entry_point" accepting a group parameter that was introduced
with Python 3.10, so we fall back to a version of "importlib_metadata"
that support this. Also note that we also only require this external
(backport) dependency for Python 3.9.