### PR TITLE
PiMixin: Enable support for ignoring provided forecast dates

### DIFF
--- a/src/rtctools/data/pi.py
+++ b/src/rtctools/data/pi.py
@@ -350,6 +350,7 @@ class Timeseries:
         basename,
         binary=True,
         pi_validate_times=False,
+        pi_read_forecast_date=True,
         make_new_file=False,
     ):
         """
@@ -454,7 +455,7 @@ class Timeseries:
                     )
 
                 el = header.find("pi:forecastDate", ns)
-                if el is not None:
+                if el is not None and pi_read_forecast_date:
                     forecast_datetime = self.__parse_date_time(el)
                 else:
                     # the timeseries has no forecastDate, so the forecastDate

--- a/src/rtctools/optimization/pi_mixin.py
+++ b/src/rtctools/optimization/pi_mixin.py
@@ -44,6 +44,9 @@ class PIMixin(IOMixin):
     #: Check consistency of timeseries
     pi_validate_timeseries = True
 
+    #: Read forecast date from timeseries_import
+    pi_read_forecast_date = True
+
     #: Check for duplicate parameters
     pi_check_for_duplicate_parameters = True
 
@@ -87,6 +90,7 @@ class PIMixin(IOMixin):
                 self.timeseries_import_basename,
                 binary=self.pi_binary_timeseries,
                 pi_validate_times=self.pi_validate_timeseries,
+                pi_read_forecast_date=self.pi_read_forecast_date,
             )
         except IOError:
             raise Exception(
@@ -101,6 +105,7 @@ class PIMixin(IOMixin):
             self.timeseries_export_basename,
             binary=self.pi_binary_timeseries,
             pi_validate_times=False,
+            pi_read_forecast_date=True,
             make_new_file=True,
         )
 

--- a/src/rtctools/simulation/pi_mixin.py
+++ b/src/rtctools/simulation/pi_mixin.py
@@ -41,6 +41,9 @@ class PIMixin(IOMixin):
     #: Check consistency of timeseries
     pi_validate_timeseries = True
 
+    #: Read forecast date from timeseries_import
+    pi_read_forecast_date = True
+
     #: Check for duplicate parameters
     pi_check_for_duplicate_parameters = True
 
@@ -89,6 +92,7 @@ class PIMixin(IOMixin):
                 self.timeseries_import_basename,
                 binary=self.pi_binary_timeseries,
                 pi_validate_times=self.pi_validate_timeseries,
+                pi_read_forecast_date=self.pi_read_forecast_date,
             )
         except FileNotFoundError:
             raise FileNotFoundError(
@@ -103,6 +107,7 @@ class PIMixin(IOMixin):
             self.timeseries_export_basename,
             binary=self.pi_binary_timeseries,
             pi_validate_times=False,
+            pi_read_forecast_date=True,
             make_new_file=True,
         )
 


### PR DESCRIPTION
An exception is raised if forecast dates were provided and they are not all equal. This option allows users to ignore provided forecast dates.