### PR TITLE
casadi_helpers: fix parameter/variable name

### DIFF
--- a/src/rtctools/_internal/casadi_helpers.py
+++ b/src/rtctools/_internal/casadi_helpers.py
@@ -5,12 +5,12 @@ import casadi as ca
 logger = logging.getLogger("rtctools")
 
 
-def is_affine(e, v):
+def is_affine(expr, symbols):
     try:
-        Af = ca.Function("f", [v], [ca.jacobian(e, v)]).expand()
-    except RuntimeError as e:
-        if "'eval_sx' not defined for" in str(e):
-            Af = ca.Function("f", [v], [ca.jacobian(e, v)])
+        Af = ca.Function("f", [symbols], [ca.jacobian(expr, symbols)]).expand()
+    except RuntimeError as error:
+        if "'eval_sx' not defined for" in str(error):
+            Af = ca.Function("f", [symbols], [ca.jacobian(expr, symbols)])
         else:
             raise
     return Af.sparsity_jac(0, 0).nnz() == 0


### PR DESCRIPTION
Use a different name for the expression parameter
and catched exception in the is_affine function.