### PR TITLE
Pymoca 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,9 @@ setup(
         "casadi >= 3.6.3, == 3.6.*, !=3.6.6",
         "numpy >= 1.16.0",
         "scipy >= 1.0.0",
-        "pymoca >= 0.9.1, == 0.9.*",
+        "pymoca == 0.11.*",
         "rtc-tools-channel-flow >= 1.2.0",
+        "rtc-tools-standard-library >= 0.1.0",
         "defusedxml >= 0.7.0",
         # Python 3.9's importlib.metadata does not support the "group" parameter
         # to entry_points yet.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "scipy >= 1.0.0",
         "pymoca == 0.11.*",
         "rtc-tools-channel-flow >= 1.2.0",
-        "rtc-tools-standard-library >= 0.1.0",
+        "rtc-tools-standard-library >= 0.1.1",
         "defusedxml >= 0.7.0",
         # Python 3.9's importlib.metadata does not support the "group" parameter
         # to entry_points yet.

--- a/tests/simulation/data/infeasible_initial_value/model_with_sym_ystart.mo
+++ b/tests/simulation/data/infeasible_initial_value/model_with_sym_ystart.mo
@@ -1,6 +1,6 @@
 model ModelWithSymbolicStart
 	parameter Real x0 = 30;
-	Real x(start=x0-10)
+	Real x(start=x0-10);
 equation
 	der(x) = -x;
 end ModelWithSymbolicStart;


### PR DESCRIPTION
The project seems seems to be stuck on pymoca `0.9.*`.

Since pymoca 0.10.0, `Modelica` and `SI` are no longer listed as builtin type ( https://github.com/pymoca/pymoca/commit/cf6d6a3b259983afe6e9d43c079da33901f17e34 ).
On the other hand, pymoca cannot yet successfully parse the Modelica Standard Library.

My proposal is to introduce [rtc-tools-standard-library](https://github.com/jgillis/rtc-tools-standard-library), a manually-curated minimal standard library replacement, exclusively tailored to rtc-tools.


