### PR TITLE
include pip install in workflow

### DIFF
--- a/.github/workflows/rtc-tools.yml
+++ b/.github/workflows/rtc-tools.yml
@@ -94,6 +94,7 @@ jobs:
         - '3.13'
     steps:
     - uses: actions/checkout@v4.1.0
+    - run: python -m pip install --upgrade pip
     - run: pip install tox
     - run: tox -vv
 


### PR DESCRIPTION
pip is now updated in the github worklow. 
This change seems to fix the dependency issue in the pipeline  