### PR TITLE
CSVLookupTableMixin: Fix infeasibilities in fitting B-spline due to auto-scaling

### DIFF
--- a/src/rtctools/optimization/csv_lookup_table_mixin.py
+++ b/src/rtctools/optimization/csv_lookup_table_mixin.py
@@ -359,6 +359,7 @@ class CSVLookupTableMixin(OptimizationProblem):
                             k=k,
                             monotonicity=mono,
                             curvature=curv,
+                            ipopt_options={"nlp_scaling_method": "none"},
                         )
                     else:
                         raise Exception(


### PR DESCRIPTION
To avoid infeasibility due to autoscaling, `nlp_scaling_method = none` is passed as `ipopt_options` to the `BSpline1D.fit` method when calling it from the `CSVLookupTableMixin` class.

The `ipopt_options` argument was already included in the `BSpline1D` class in a previous commit. [Commit Link](https://github.com/Deltares/rtc-tools/commit/60b3d2a75dcc61890ffe937808df9fa3d0689563)

This change fixes the failing tests due to numerical issues in Bspline1.
