### PR TITLE
CollInt: Fix __debug_check_state_output_scaling for ensemble members

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -3112,7 +3112,7 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
         variable_to_all_indices = {k: set(v) for k, v in indices[0].items()}
         for ensemble_indices in indices[1:]:
             for k, v in ensemble_indices.items():
-                variable_to_all_indices[k] |= v
+                variable_to_all_indices[k] |= set(v)
 
         if len(inds_up) > 0:
             exceedences = []


### PR DESCRIPTION
The ensemble indices are lists. We already converted the the first ensemble member's to a set, but not the remaining ones. Trying to do `|=` with a list on the right-hand side is not allowed, so we have to explicitly converted to a set first.