### PR TITLE
Optimization: update suggested inheritance order

### DIFF
--- a/src/rtctools/util.py
+++ b/src/rtctools/util.py
@@ -110,6 +110,7 @@ def run_optimization_problem(
             "GoalProgrammingMixin",
             "PIMixin",
             "CSVMixin",
+            "IOMixin",
             "ModelicaMixin",
             "PlanningMixin",
             "ControlTreeMixin",


### PR DESCRIPTION
Update the suggested inheritance order for an optimization problem. In particular, add IOMixin to the list.
If GoalProgrammingMixin and IOMixin are interchanged, for example, this can lead to unexpected results/errors.