### PR TITLE
Add sonar code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 source = rtctools
 omit = src/rtctools/_version.py
+relative_files = True
 
 [report]
 show_missing = true

--- a/.github/workflows/rtc-tools.yml
+++ b/.github/workflows/rtc-tools.yml
@@ -20,20 +20,8 @@ jobs:
     - run: pip install pre-commit
     - run: pre-commit run --all-files --show-diff-on-failure
 
-  security:  # Also includes a few basic code quality checks.
-    name: sonarqube
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis.
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   build:
-    needs: [style, security]
+    needs: [style]
     runs-on: ubuntu-latest
     container:
       image: python:3.9
@@ -84,8 +72,29 @@ jobs:
     - uses: actions/checkout@v4.1.0
     - run: pip install tox
     - run: tox -vv
-  #   - run: pip install codecov
-  #   - run: codecov --token=$CODECOV_TOKEN
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: coverage-report
+        retention-days: 7
+        path: coverage.xml
+
+  sonar:
+    needs: [coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis.
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   examples-linux:
     needs: build

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Pipeline](https://github.com/deltares/rtc-tools/actions/workflows/rtc-tools.yml/badge.svg)](
     https://github.com/deltares/rtc-tools/actions/workflows/rtc-tools.yml
 )
-[![Coverage](https://codecov.io/gl/deltares/rtc-tools/branch/master/graph/badge.svg)](
-    https://codecov.io/gl/deltares/rtc-tools
-)
+[![Coverage](
+    https://sonarcloud.io/api/project_badges/measure?project=Deltares_rtc-tools&metric=coverage
+)](https://sonarcloud.io/summary/new_code?id=Deltares_rtc-tools)
 
 > **NOTE** The rtc-tools repository has been migrated from gitlab to here;
 see [migration from gitlab](#migration-from-gitlab).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,10 +5,12 @@ sonar.organization=deltares
 sonar.projectName=rtc-tools
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=.
+sonar.sources=src/
+sonar.tests=tests/
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
 # Python version (for python projects only)
 sonar.python.version=3.9, 3.10, 3.11, 3.12, 3.13
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,4 @@ commands =
   - coverage run --parallel-mode -m pytest --ignore=tests/examples {posargs} tests
   - coverage combine
   - coverage report
+  - coverage xml


### PR DESCRIPTION
Run a code coverage check and let sonarcloud parse it.

The total code coverage percentage will only be visible on sonarcloud after this branch has been merged. For non-main branches, sonarcloud only reports code coverage of new code lines. Since this branch doesn't change any source code, sonarcloud will claim too few lines changed to determine the code coverage.