### PR TITLE
Fix rtc-tools-download-examples script

### DIFF
--- a/src/rtctools/rtctoolsapp.py
+++ b/src/rtctools/rtctoolsapp.py
@@ -104,7 +104,6 @@ def download_examples(*args):
     from zipfile import ZipFile
 
     version = rtctools.__version__
-    rtc_full_name = "rtc-tools-{}".format(version)
     try:
         url = "https://github.com/deltares/rtc-tools/zipball/{}".format(version)
 
@@ -117,11 +116,12 @@ def download_examples(*args):
 
     with ZipFile(local_filename, "r") as z:
         target = path / "rtc-tools-examples"
-        prefix = "{}/examples/".format(rtc_full_name)
+        zip_folder_name = next(x for x in z.namelist() if x.startswith("Deltares-rtc-tools-"))
+        prefix = "{}/examples/".format(zip_folder_name.rstrip("/"))
         members = [x for x in z.namelist() if x.startswith(prefix)]
         z.extractall(members=members)
         shutil.move(prefix, target)
-        shutil.rmtree(rtc_full_name)
+        shutil.rmtree(zip_folder_name)
 
         sys.exit("Succesfully downloaded the RTC-Tools examples to '{}'".format(target.resolve()))
 


### PR DESCRIPTION
On GitLab, the zipfile of the tree that was downloaded contained a folder with the tag name in it. For GitHub however, the folder is names '<group>-<repo>-<sha>', e.g. "Deltares-rtc-tools-1c7b20a". We therefore just find a folder named like that instead.