### PR TITLE
Doc: Update supported Python versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Commit messages should have the following structure:
 
 To set up your development environment, you will need:
 
-- Python 3.9 or higher
+- Python 3.9 or higher (up to 3.13)
 - Git
 
 You can clone the repository and install it from source:

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -4,7 +4,7 @@ Getting Started
 Installation
 ============
 
-Python 3.9 is recommended for running RTC-Tools.
+Python 3.9 or newer (up to 3.13) is recommended for running RTC-Tools.
 
 For most users, the easiest way to install RTC-Tools using the `pip <https://pip.pypa.io/>`_ package manager.
 


### PR DESCRIPTION
Documentation files _Getting started_ and _Contributing_ now explicitly indicate the supported Python versions (3.9-3.13) 