### PR TITLE
CollInt: Fix ensemble-varying parameters if first member value is 1

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -670,7 +670,7 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
                 for ensemble_member in range(self.ensemble_size)
             ]
             if (
-                len(values) == 1 or (np.all(values) == values[0])
+                len(values) == 1 or all(v == values[0] for v in values)
             ) and parameter.name() not in dynamic_parameter_names:
                 constant_parameters.append(parameter)
                 constant_parameter_values.append(values[0])


### PR DESCRIPTION
The check to see if the parameters were constant/equal over all ensemble members was wrong. The if statement would evaluate to 'true' for e.g. `[1, 0.5]`. We would then erroneously use the same parameter value of `1` for all members.

In more detail on what exactly was happening:

  `np.all(values)` evaluates to `np.True_`

  `np.True == values[0]` casts the left-hand side to a float/int, so it
  becomes

  `1.0 == values[0]` which is True if the first member is 1 (or 1.0)

We add a test case to cover this scenario, by mostly copy-pasting an existing one for ensembles, but adjusting it to vary the _parameter_ value instead.