### PR TITLE
CollInt: Support returning times from 'states_in()'

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -2639,10 +2639,21 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
 
         return x, t
 
-    def states_in(self, variable, t0=None, tf=None, ensemble_member=0):
-        x, _ = self.__states_times_in(variable, t0, tf, ensemble_member)
+    def states_in(
+        self,
+        variable: str,
+        t0: float = None,
+        tf: float = None,
+        ensemble_member: int = 0,
+        *,
+        return_times: bool = False,
+    ) -> Union[ca.MX, tuple[ca.DM, ca.MX]]:
+        x, t = self.__states_times_in(variable, t0, tf, ensemble_member)
 
-        return x
+        if return_times:
+            return x, t
+        else:
+            return x
 
     def integral(self, variable, t0=None, tf=None, ensemble_member=0):
         x, t = self.__states_times_in(variable, t0, tf, ensemble_member)


### PR DESCRIPTION
Internally the `times` were already returned with the `__states_time_in` method. Exposing this functinality to the user will allow them to e.g. compute integrals/sums of algebraic states/control inputs.

Our implementation of `integral` takes averages over a time step, which makes sense for state variables like reservoir volumes. But if one is interested in a sum/average of algebraic states, they would want to exclude the value at t0 (assuming backwards euler). This is non-trivial, and would mean the user has to reimplent the logic in `__states_time_in` for history etc.

Note that we may want to support different ways of calculating the integral directly in `integral()` in the future, but at least optionally returning the times from `states_in()` in this commit already allows this and more in a generic way.