### PR TITLE
CollInt/casadi_helpers: Fix interpolation for single-timestep variables

### DIFF
--- a/src/rtctools/_internal/casadi_helpers.py
+++ b/src/rtctools/_internal/casadi_helpers.py
@@ -52,4 +52,12 @@ def interpolate(ts, xs, t, equidistant, mode=0):
         mode_str = "floor"
     else:
         mode_str = "ceil"
+
+    # CasADi fails if there is just a single point. Just "extrapolate" based on
+    # that point, just as CasADi would do for entries in 't' outside the range
+    # of 'ts'.
+    if len(ts) == 1:
+        assert xs.size1() == 1
+        return ca.vertcat(*[xs] * len(t))
+
     return ca.interp1d(ts, xs, t, mode_str, equidistant)


### PR DESCRIPTION
Other interpolation tests already cover a variable with different time steps than the overall collocation time steps. In the case where this 'different' means just a _single_ time step, the interpolation with CasADi would fail.

Note that 'interp1d' already extrapolated outside the range of `ts`, it just refused to do so for a single timestep.