### PR TITLE
CollInt/_debug_*: Fix tol_down warnings in coefficient check

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -2947,8 +2947,19 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
             "{} & {}, {} & {}".format(max_constr_A, min_constr_A, max_constr_b, min_constr_b)
         )
 
-        maxs = [x for x in [max_constr_A, max_constr_b, max_obj_A, obj_b] if x is not None]
-        mins = [x for x in [min_constr_A, min_constr_b, min_obj_A, obj_b] if x is not None]
+        # Filter out exactly zero, as those entries do not show up in the
+        # matrix. Shut up SonarCloud warning about this exact-to-zero
+        # comparison.
+        maxs = [
+            x
+            for x in [max_constr_A, max_constr_b, max_obj_A, obj_b]
+            if x is not None and x != 0.0  # NOSONAR
+        ]
+        mins = [
+            x
+            for x in [min_constr_A, min_constr_b, min_obj_A, obj_b]
+            if x is not None and x != 0.0  # NOSONAR
+        ]
         if (maxs and max(maxs) > tol_up) or (mins and min(mins) < tol_down):
             logger.info("Jacobian matrix /constants coefficients values outside typical range!")
 

--- a/tests/optimization/test_debug_checks.py
+++ b/tests/optimization/test_debug_checks.py
@@ -101,6 +101,14 @@ class TestCheckMatrixCoefficients(TestCase):
             " (max > 100, min < 0.01, or max / min > 1000):",
         )
 
+    def test_matrix_coefficient_small_skipped(self):
+        self._run_test(
+            ModelMatrixCoeffSmall,
+            "INFO:rtctools:Jacobian matrix /constants coefficients values outside typical range!",
+            "assertNotIn",
+            tol_down=1e-6,
+        )
+
     def test_matrix_coefficient_row_range(self):
         self._run_test(
             ModelMatrixCoeffRowRange,


### PR DESCRIPTION
- [x] Needs test; e.g. a coefficient of 1e-6 and 0.0, setting tol_down to 1e-12. It would trigger on the 0.0, which this commit fixes.