### PR TITLE
Fix symbolic parameter substitution

### DIFF
--- a/src/rtctools/_internal/casadi_helpers.py
+++ b/src/rtctools/_internal/casadi_helpers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 
 import casadi as ca
 
@@ -37,7 +38,9 @@ def reduce_matvec(e, v):
     return ca.reshape(ca.mtimes(A, v), e.shape)
 
 
-def substitute_in_external(expr, symbols, values):
+def substitute_in_external(
+    expr: ca.MX, symbols: list[ca.MX], values: list[Union[ca.MX, ca.DM, float]]
+):
     if len(symbols) == 0 or all(isinstance(x, ca.DM) for x in expr):
         return expr
     else:

--- a/src/rtctools/_internal/casadi_helpers.py
+++ b/src/rtctools/_internal/casadi_helpers.py
@@ -44,7 +44,7 @@ def substitute_in_external(
     if len(symbols) == 0 or all(isinstance(x, ca.DM) for x in expr):
         return expr
     else:
-        f = ca.Function("f", symbols, expr)
+        f = ca.Function("f", symbols, expr).expand()
         return f.call(values, True, False)
 
 

--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -386,7 +386,9 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
             ):
                 parameter_values = nullvertcat(*parameter_values)
                 [parameter_values] = substitute_in_external(
-                    [parameter_values], self.dae_variables["parameters"], parameter_values
+                    [parameter_values],
+                    self.dae_variables["parameters"],
+                    ca.vertsplit(parameter_values),
                 )
             else:
                 parameter_values = nullvertcat(*parameter_values)


### PR DESCRIPTION
Relevant with something like
```
    def compiler_options(self):
        options = super().compiler_options()
        options["replace_parameter_expressions"] = False
        options["resolve_parameter_values"] = False
        return options
```

- [ ] Test with symbolic parameters in model, e.g. 

```Modelica
parameter Real a = 2.0;
parameter Real b = 10.0;
parameter Real ub = a * b;

Real x(max=ub);
```

