### PR TITLE
ControlTreeMixin:  Use int64 rather than int16 for control indices

### DIFF
--- a/src/rtctools/optimization/control_tree_mixin.py
+++ b/src/rtctools/optimization/control_tree_mixin.py
@@ -50,7 +50,7 @@ class ControlTreeMixin(OptimizationProblem):
         return options
 
     def discretize_control(self, variable, ensemble_member, times, offset):
-        control_indices = np.zeros(len(times), dtype=np.int16)
+        control_indices = np.zeros(len(times), dtype=np.int64)
         for branch, members in self.__branches.items():
             if ensemble_member not in members:
                 continue


### PR DESCRIPTION
Nowhere else in the code do we use int16, and its use here was causing overflows for larger problems.