### PR TITLE
pyproject.toml: Fix allowing CasADi 3.7.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Operating System :: MacOS"
 ]
 dependencies = [
-    "casadi >= 3.6.3, <= 3.7, !=3.6.6",
+    "casadi >= 3.6.3, < 3.8, !=3.6.6",
     "numpy >= 1.16.0",
     "scipy >= 1.0.0",
     "pymoca >= 0.9.1, == 0.9.*",


### PR DESCRIPTION
A `<= 3.7` is equivalent to `<= 3.7.0`. We want to allow the entire 3.7 series of CasADi, and with `<= 3.7.*` not being allowed, we use `< 3.8`.