### PR TITLE
docs: Update link to 'Modelica by Example' in modelica_models.rst

### DIFF
--- a/doc/optimization/modelica_models.rst
+++ b/doc/optimization/modelica_models.rst
@@ -1,7 +1,7 @@
 Modelica models
 ===============
 
-To learn the basics of modelling with Modelica, please refer to the online book `Modelica by Example <http://book.xogeny.com/>`_. 
+To learn the basics of modelling with Modelica, please refer to the online book `Modelica by Example <https://mbe.modelica.university/>`_. 
 
 .. autoclass:: rtctools.optimization.modelica_mixin.ModelicaMixin
     :members: compiler_options


### PR DESCRIPTION
The link to the Modelica book was outdated and was pointing to the wrong page. The correct link has now been included.