### PR TITLE
Workflows: Pin setup-uv to specific commit SHA for security an…

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -19,11 +19,12 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: true
         cache-dependency-glob: "uv.lock"
+        github-token: ${{ github.token }}  # Avoid API rate limits
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
 #   PYPI_PASSWORD: "${{ secrets.PYPI_PASSWORD }}"
 #   CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN}}"
 
+permissions:
+  contents: read
+
 jobs:
   style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces security improvements for GitHub Actions usage in the repository The main changes include adding documentation for third-party actions security, pinning the `astral-sh/setup-uv` action to a specific commit SHA, and enforcing read-only permissions across all workflow jobs per Deltares policy.

* Added `.github/THIRD_PARTY_ACTIONS.md` to document all third-party GitHub Actions, their vetting status, security assessments, and best practices according to Deltares guidelines.

* Updated `.github/actions/setup-python/action.yml` to pin `astral-sh/setup-uv` to commit SHA `3259c6206f993105e3a61b142c2d97bf4b9ef83d`, added security comments, and ensured the action uses a GitHub token only for rate limiting.

* Set default workflow permissions to read-only (`contents: read`) in `.github/workflows/rtc-tools.yml` for all jobs, explicitly specifying minimal permissions per job as recommended by Deltares policy.

Fixes #1715 1715