### PR TITLE
setup.py: Fix allowing CasADi 3.7.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     install_requires=[
-        "casadi >= 3.6.3, <= 3.7, !=3.6.6",
+        "casadi >= 3.6.3, < 3.8, !=3.6.6",
         "numpy >= 1.16.0",
         "scipy >= 1.0.0",
         "pymoca >= 0.9.1, == 0.9.*",


### PR DESCRIPTION
For the maintenance 2.7, the Casadi version change is replicated from #1708:
A `<= 3.7` is equivalent to `<= 3.7.0`. We want to allow the entire 3.7 series of CasADi, and with `<= 3.7.*` not being allowed, we use `< 3.8`.

