### PR TITLE
pi: Check assumption of zero-based ensembleMemberIndex.

### DIFF
--- a/tests/optimization/data/non_zero_indexed_ensembles/Model.mo
+++ b/tests/optimization/data/non_zero_indexed_ensembles/Model.mo
@@ -1,0 +1,46 @@
+model Model
+	Real x(start=1.1, nominal = 10);
+	Real w(start=0.0);
+	Real alias;
+
+	Real v_initial(start=2.1, fixed=true);
+
+	parameter Real k = 1.0;
+
+	input Real u(fixed=false);
+
+	output Real y;
+
+	output Real z;
+
+	output Real x_delayed;
+	Real x_delayed_extra;
+
+	output Real switched;
+
+	input Real constant_input(fixed=true);
+	output Real constant_output;
+
+equation
+	der(x) = k * x + u;
+	der(w) = x;
+	der(v_initial) = 0;
+
+	alias = x;
+
+	y + x = 3.0;
+
+	z = alias^2 + sin(time);
+
+	x_delayed = delay(x, 0.1);
+	x_delayed_extra = delay(x, 0.125);
+
+	if x > 0.5 then
+		switched = 1.0;
+	else
+		switched = 2.0;
+	end if;
+
+	constant_output = constant_input;
+
+end Model;

--- a/tests/optimization/data/non_zero_indexed_ensembles/rtcDataConfig.xml
+++ b/tests/optimization/data/non_zero_indexed_ensembles/rtcDataConfig.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rtcDataConfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rtc="http://www.wldelft.nl/fews" xmlns="http://www.wldelft.nl/fews" xsi:schemaLocation="http://www.wldelft.nl/fews ../../../xsd/rtcDataConfig.xsd">
+	<timeSeries id="u_Min">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U_Min</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="u_Max">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U_Max</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="u">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="x">
+		<PITimeSeries>
+			<locationId>States</locationId>
+			<parameterId>X</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="w">
+		<PITimeSeries>
+			<locationId>States</locationId>
+			<parameterId>W</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="constant_input">
+		<PITimeSeries>
+			<locationId>Inputs</locationId>
+			<parameterId>I</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="k">
+		<PITimeSeries>
+			<locationId>Parameters</locationId>
+			<parameterId>K</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<parameter id="SV_H_y">
+		<PIParameter>
+			<modelId>SV</modelId>
+			<locationId>H</locationId>
+			<parameterId>y</parameterId>
+		</PIParameter>
+	</parameter>
+	<parameter id="SV_V_y">
+		<PIParameter>
+			<modelId>SV</modelId>
+			<locationId>V</locationId>
+			<parameterId>y</parameterId>
+		</PIParameter>
+	</parameter>
+</rtcDataConfig>

--- a/tests/optimization/data/non_zero_indexed_ensembles/rtcParameterConfig.xml
+++ b/tests/optimization/data/non_zero_indexed_ensembles/rtcParameterConfig.xml
@@ -1,0 +1,19 @@
+<ns0:parameters xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.5" xsi:schemaLocation="http://www.wldelft.nl/fews/PI http://fews.wldelft.nl/schemas/version1.0/pi-schemas/pi_modelparameters.xsd">
+	<ns0:group id="parameters" name="parameters" readonly="false">
+		<ns0:parameter id="k">
+			<ns0:dblValue>1.01</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="states" name="states" readonly="false">
+		<ns0:parameter id="alias">
+			<ns0:dblValue>1.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="nested" readonly="false">
+		<ns0:locationId>V</ns0:locationId>
+		<ns0:model>SV</ns0:model>
+		<ns0:parameter id="y">
+			<ns0:dblValue>22.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+</ns0:parameters>

--- a/tests/optimization/data/non_zero_indexed_ensembles/rtcParameterConfig_extra.xml
+++ b/tests/optimization/data/non_zero_indexed_ensembles/rtcParameterConfig_extra.xml
@@ -1,0 +1,22 @@
+<ns0:parameters xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.5" xsi:schemaLocation="http://www.wldelft.nl/fews/PI http://fews.wldelft.nl/schemas/version1.0/pi-schemas/pi_modelparameters.xsd">
+	<ns0:group id="parameters" name="parameters" readonly="false">
+		<ns0:parameter id="j">
+			<ns0:dblValue>12.01</ns0:dblValue>
+		</ns0:parameter>
+		<ns0:parameter id="b">
+			<ns0:dblValue>13.01</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="states" name="states" readonly="false">
+		<ns0:parameter id="y">
+			<ns0:dblValue>12.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="nested" readonly="false">
+		<ns0:locationId>H</ns0:locationId>
+		<ns0:model>SV</ns0:model>
+		<ns0:parameter id="y">
+			<ns0:dblValue>22.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+</ns0:parameters>

--- a/tests/optimization/data/non_zero_indexed_ensembles/timeseries_import.xml
+++ b/tests/optimization/data/non_zero_indexed_ensembles/timeseries_import.xml
@@ -1,0 +1,373 @@
+<ns0:TimeSeries xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="http://www.wldelft.nl/fews/PI ../../xsd/pi_timeseries.xsd">
+	<ns0:timeZone>0.0</ns0:timeZone>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Min</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="-2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="-2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Max</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>X</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.02" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>W</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="0.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Inputs</ns0:locationId>
+			<ns0:parameterId>I</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="1.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Min</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble12</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>12</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="-2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="-2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Max</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble12</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>12</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>X</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble12</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>12</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.02" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>W</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble12</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>12</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="0.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Inputs</ns0:locationId>
+			<ns0:parameterId>I</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble12</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>12</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="1.0" />
+	</ns0:series>
+</ns0:TimeSeries>

--- a/tests/optimization/data/single_non_zero_ensemble_index/Model.mo
+++ b/tests/optimization/data/single_non_zero_ensemble_index/Model.mo
@@ -1,0 +1,46 @@
+model Model
+	Real x(start=1.1, nominal = 10);
+	Real w(start=0.0);
+	Real alias;
+
+	Real v_initial(start=2.1, fixed=true);
+
+	parameter Real k = 1.0;
+
+	input Real u(fixed=false);
+
+	output Real y;
+
+	output Real z;
+
+	output Real x_delayed;
+	Real x_delayed_extra;
+
+	output Real switched;
+
+	input Real constant_input(fixed=true);
+	output Real constant_output;
+
+equation
+	der(x) = k * x + u;
+	der(w) = x;
+	der(v_initial) = 0;
+
+	alias = x;
+
+	y + x = 3.0;
+
+	z = alias^2 + sin(time);
+
+	x_delayed = delay(x, 0.1);
+	x_delayed_extra = delay(x, 0.125);
+
+	if x > 0.5 then
+		switched = 1.0;
+	else
+		switched = 2.0;
+	end if;
+
+	constant_output = constant_input;
+
+end Model;

--- a/tests/optimization/data/single_non_zero_ensemble_index/rtcDataConfig.xml
+++ b/tests/optimization/data/single_non_zero_ensemble_index/rtcDataConfig.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rtcDataConfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rtc="http://www.wldelft.nl/fews" xmlns="http://www.wldelft.nl/fews" xsi:schemaLocation="http://www.wldelft.nl/fews ../../../xsd/rtcDataConfig.xsd">
+	<timeSeries id="u_Min">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U_Min</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="u_Max">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U_Max</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="u">
+		<PITimeSeries>
+			<locationId>Controls</locationId>
+			<parameterId>U</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="x">
+		<PITimeSeries>
+			<locationId>States</locationId>
+			<parameterId>X</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="w">
+		<PITimeSeries>
+			<locationId>States</locationId>
+			<parameterId>W</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="constant_input">
+		<PITimeSeries>
+			<locationId>Inputs</locationId>
+			<parameterId>I</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<timeSeries id="k">
+		<PITimeSeries>
+			<locationId>Parameters</locationId>
+			<parameterId>K</parameterId>
+		</PITimeSeries>
+	</timeSeries>
+	<parameter id="SV_H_y">
+		<PIParameter>
+			<modelId>SV</modelId>
+			<locationId>H</locationId>
+			<parameterId>y</parameterId>
+		</PIParameter>
+	</parameter>
+	<parameter id="SV_V_y">
+		<PIParameter>
+			<modelId>SV</modelId>
+			<locationId>V</locationId>
+			<parameterId>y</parameterId>
+		</PIParameter>
+	</parameter>
+</rtcDataConfig>

--- a/tests/optimization/data/single_non_zero_ensemble_index/rtcParameterConfig.xml
+++ b/tests/optimization/data/single_non_zero_ensemble_index/rtcParameterConfig.xml
@@ -1,0 +1,19 @@
+<ns0:parameters xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.5" xsi:schemaLocation="http://www.wldelft.nl/fews/PI http://fews.wldelft.nl/schemas/version1.0/pi-schemas/pi_modelparameters.xsd">
+	<ns0:group id="parameters" name="parameters" readonly="false">
+		<ns0:parameter id="k">
+			<ns0:dblValue>1.01</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="states" name="states" readonly="false">
+		<ns0:parameter id="alias">
+			<ns0:dblValue>1.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="nested" readonly="false">
+		<ns0:locationId>V</ns0:locationId>
+		<ns0:model>SV</ns0:model>
+		<ns0:parameter id="y">
+			<ns0:dblValue>22.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+</ns0:parameters>

--- a/tests/optimization/data/single_non_zero_ensemble_index/rtcParameterConfig_extra.xml
+++ b/tests/optimization/data/single_non_zero_ensemble_index/rtcParameterConfig_extra.xml
@@ -1,0 +1,22 @@
+<ns0:parameters xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.5" xsi:schemaLocation="http://www.wldelft.nl/fews/PI http://fews.wldelft.nl/schemas/version1.0/pi-schemas/pi_modelparameters.xsd">
+	<ns0:group id="parameters" name="parameters" readonly="false">
+		<ns0:parameter id="j">
+			<ns0:dblValue>12.01</ns0:dblValue>
+		</ns0:parameter>
+		<ns0:parameter id="b">
+			<ns0:dblValue>13.01</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="states" name="states" readonly="false">
+		<ns0:parameter id="y">
+			<ns0:dblValue>12.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+	<ns0:group id="nested" readonly="false">
+		<ns0:locationId>H</ns0:locationId>
+		<ns0:model>SV</ns0:model>
+		<ns0:parameter id="y">
+			<ns0:dblValue>22.02</ns0:dblValue>
+		</ns0:parameter>
+	</ns0:group>
+</ns0:parameters>

--- a/tests/optimization/data/single_non_zero_ensemble_index/timeseries_import.xml
+++ b/tests/optimization/data/single_non_zero_ensemble_index/timeseries_import.xml
@@ -1,0 +1,188 @@
+<ns0:TimeSeries xmlns:ns0="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="http://www.wldelft.nl/fews/PI ../../xsd/pi_timeseries.xsd">
+	<ns0:timeZone>0.0</ns0:timeZone>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Min</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="-2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="-2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="-2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Controls</ns0:locationId>
+			<ns0:parameterId>U_Max</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="2.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="2.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="2.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>X</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.02" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>States</ns0:locationId>
+			<ns0:parameterId>W</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="0.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="0.03" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="0.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="0.0" />
+	</ns0:series>
+	<ns0:series>
+		<ns0:header>
+			<ns0:type>instantaneous</ns0:type>
+			<ns0:locationId>Inputs</ns0:locationId>
+			<ns0:parameterId>I</ns0:parameterId>
+			<ns0:ensembleId>test_ensemble</ns0:ensembleId>
+			<ns0:ensembleMemberIndex>10</ns0:ensembleMemberIndex>
+			<ns0:timeStep multiplier="3600" unit="second" />
+			<ns0:startDate date="2013-05-19" time="22:00:00" />
+			<ns0:forecastDate date="2013-05-19" time="22:00:00" />
+			<ns0:endDate date="2013-05-20" time="19:00:00" />
+			<ns0:missVal>-999.0</ns0:missVal>
+			<ns0:units>m3/s</ns0:units>
+		</ns0:header>
+		<ns0:event date="2013-05-19" flag="0" time="22:00:00" value="1.0" />
+		<ns0:event date="2013-05-19" flag="0" time="23:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="00:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="01:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="02:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="03:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="04:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="05:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="06:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="07:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="08:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="09:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="10:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="11:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="12:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="13:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="14:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="15:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="16:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="17:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="18:00:00" value="1.0" />
+		<ns0:event date="2013-05-20" flag="0" time="19:00:00" value="1.0" />
+	</ns0:series>
+</ns0:TimeSeries>


### PR DESCRIPTION
Explicitly check the existing assumption of zero-based ensembleMemberIndex. Raise a value error if this is not the case.

Relax this assumption if only a single ensembleMemberIndex is present. This allows more flexibility and the ability to execute model runs where a single non-zero ensembleMemberIndex is present. 