### PR TITLE
SinglePassGPMixin: Fix seeding of epsilons for the first priority

### DIFF
--- a/src/rtctools/optimization/single_pass_goal_programming_mixin.py
+++ b/src/rtctools/optimization/single_pass_goal_programming_mixin.py
@@ -149,7 +149,26 @@ class SinglePassGoalProgrammingMixin(_GoalProgrammingMixinBase):
 
     def seed(self, ensemble_member):
         assert self._gp_first_run
-        return super().seed(ensemble_member)
+
+        seed = super().seed(ensemble_member)
+
+        # Seed epsilons of current priority
+        for epsilon in self.__problem_epsilons:
+            eps_size = epsilon.size1()
+            if eps_size > 1:
+                seed[epsilon.name()] = np.ones(eps_size)
+            else:
+                seed[epsilon.name()] = 1.0
+
+        times = self.times()
+        for epsilon in self.__problem_path_epsilons:
+            eps_size = epsilon.size1()
+            if eps_size > 1:
+                seed[epsilon.name()] = Timeseries(times, np.ones((eps_size, len(times))))
+            else:
+                seed[epsilon.name()] = Timeseries(times, np.ones(len(times)))
+
+        return seed
 
     def constraints(self, ensemble_member):
         constraints = super().constraints(ensemble_member)

--- a/tests/optimization/test_single_pass_goal_programming.py
+++ b/tests/optimization/test_single_pass_goal_programming.py
@@ -66,6 +66,7 @@ class ModelPathGoals:
         self._state_vectors = []
         self._solver_outputs = []
         self._constraints = []
+        self._initial_seed = None
 
     def times(self, variable=None):
         # Collocation points
@@ -83,6 +84,11 @@ class ModelPathGoals:
             np.hstack(([1.0], np.linspace(1.0, 0.0, 21))),
         )
         return constant_inputs
+
+    def seed(self, ensemble_member):
+        if self._initial_seed is None:
+            self._initial_seed = super().seed(ensemble_member)
+        return self._initial_seed
 
     def bounds(self):
         bounds = super().bounds()
@@ -216,6 +222,17 @@ class TestSinglePassGoalProgramming(TestCase):
         np.testing.assert_array_equal(
             self.problem_update._seeds[-1], self.problem_update._solver_outputs[-2]
         )
+
+    def test_initial_seed(self):
+        """
+        Every goal's epsilon variable should be present in the initial seed, and
+        should be set to one.
+        """
+        n_goals = len(self.problem_append.path_goals()) + len(self.problem_append.goals())
+        self.assertEqual(len(self.problem_append._initial_seed.keys()), n_goals)
+
+        for ts in self.problem_append._initial_seed.values():
+            np.testing.assert_equal(ts.values, 1.0)
 
 
 class ModelSinglePassGoalProgrammingCachingQPSol(ModelSinglePassGoalProgrammingAppend):


### PR DESCRIPTION
The seed() method for SinglePassGPMixin just returned the seed of GPMixinBase, but that one does not contain the seed of the epsilons that we add to the optimization problem.  Similar to "regular" GoalProgrammingMixin, we need to make sure to seed the epsilons to 1.0 for the first priority. We therefore copy-paste the relevant block over to SinglePassGPMixin.

Note that the `seed()` method for SinglePassGPMixin is only called for the first priority. Further priorities are handled by using the solver output of the previous priority as the seed.