### PR TITLE
doc/conf.py: Fix version import after hatch-vcs migration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@
 import os
 import re
 
-from rtctools._version import get_versions
+from rtctools.version import __version__
 
 # -- General configuration ------------------------------------------------
 
@@ -65,8 +65,7 @@ author = "Deltares"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-release = get_versions()["version"]
-del get_versions
+release = __version__
 
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])


### PR DESCRIPTION
The migration to hatch-vcs in fb8ea4c removed the versioneer-generated `rtctools._version` module. We have to update conf.py to import `__version__` from the new `rtctools.version` module instead.