### PR TITLE
 Fix NumPy 2.x compatibility for seed value assignment

### DIFF
--- a/src/rtctools/optimization/collocated_integrated_optimization_problem.py
+++ b/src/rtctools/optimization/collocated_integrated_optimization_problem.py
@@ -2217,15 +2217,26 @@ class CollocatedIntegratedOptimizationProblem(OptimizationProblem, metaclass=ABC
                         )
 
                     if isinstance(seed_k, Timeseries):
-                        x0[inds] = (
+                        seed_k = (
                             self.interpolate(
                                 times, seed_k.times, seed_k.values, 0, 0, interpolation_method
                             )
                             .transpose()
                             .ravel()
                         )
-                    else:
-                        x0[inds] = seed_k
+                    elif isinstance(seed_k, np.ndarray):
+                        seed_k = seed_k.ravel()
+
+                    # NumPy 2.x requires explicit scalar extraction for single-index assignment
+                    if isinstance(seed_k, np.ndarray) and isinstance(inds, (int, np.integer)):
+                        if seed_k.size != 1:
+                            raise ValueError(
+                                f"Seed for '{variable}' has {seed_k.size} elements, "
+                                "expected 1 for scalar index"
+                            )
+                        seed_k = seed_k.item()
+
+                    x0[inds] = seed_k
 
                     x0[inds] /= nominal
                 except KeyError:


### PR DESCRIPTION
  - Fixes [CI failures](https://github.com/rtc-tools/rtc-tools/actions/runs/20850926033/job/59905601733) caused by NumPy 2.4+ removing implicit array-to-scalar conversion
  - In `_collint_get_x0`, when assigning seed values to `x0[inds]` where `inds` is a single integer index, NumPy 2.x now raises `ValueError: setting an array element with a sequence`
  - The fix explicitly extracts scalar values using `.item()` when the index is an integer, for both `Timeseries` and `np.ndarray` seed values
  - Backwards compatible: `.item()` and `.ravel()` are available in all NumPy versions

  Tested
  - Tests fail without fix on NumPy 2.4.1
  - All tests pass with fix on NumPy 2.4.1
  - No deprecation warnings remain on NumPy 2.3.5
  

